### PR TITLE
Use the error decription of the server error replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opalkelly/frontpanel-ws",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Front Panel Web API",
   "author": "Opal Kelly <support@opalkelly.com>",
   "main": "lib/frontpanel-ws.js",

--- a/src/lib/ws-async.ts
+++ b/src/lib/ws-async.ts
@@ -364,10 +364,15 @@ export class AsyncWebSocket {
             } else {
                 const errorCode: ErrorCode = elements[0];
                 if (errorCode !== NoError) {
-                    replyError = new FrontPanelError(
-                        errorCode,
-                        `Reply #${replyId} failed`
-                    );
+                    let errorMessage = `Reply #${replyId} failed`;
+
+                    // Append the error description, if it isn't an empty string.
+                    const errorDescription: string = elements[1];
+                    if (errorDescription) {
+                        errorMessage += `: '${errorDescription}'`;
+                    }
+
+                    replyError = new FrontPanelError(errorCode, errorMessage);
                 }
             }
             elements.shift();


### PR DESCRIPTION
The server already send the error description in error replies. So use it in
the error message, if it's not an empty string.