### PR TITLE
Add support for hasQuadConfigFlash device info field

### DIFF
--- a/samples/browser/assets/js/frontpanel-ws.js
+++ b/samples/browser/assets/js/frontpanel-ws.js
@@ -394,7 +394,8 @@ var FrontPanel = /** @class */ (function () {
                             fpgaVendor: info.data[22],
                             interfaceCount: info.data[23],
                             interfaceIndex: info.data[24],
-                            configuresFromSystemFlash: info.data[25]
+                            configuresFromSystemFlash: info.data[25],
+                            hasQuadConfigFlash: info.data[26]
                         };
                         return [2 /*return*/, result];
                 }

--- a/src/lib/device-info.ts
+++ b/src/lib/device-info.ts
@@ -136,6 +136,11 @@ export interface IDeviceInfo {
      * device is configured from its FPGA flash.
      */
     configuresFromSystemFlash: boolean;
+
+    /**
+     * True if the device flash has quad SPI I/O.
+     */
+    hasQuadConfigFlash: boolean;
 }
 
 export enum ProductID {

--- a/src/lib/frontpanel.spec.ts
+++ b/src/lib/frontpanel.spec.ts
@@ -61,6 +61,7 @@ describe('FrontPanel', () => {
         expect(info.serialNumber).to.have.lengthOf.at.most(
             MAX_SERIALNUMBER_LENGTH
         );
+        expect(info.hasQuadConfigFlash).to.equal(false);
     });
 
     it('should configure the device', async () => {

--- a/src/lib/frontpanel.ts
+++ b/src/lib/frontpanel.ts
@@ -23,7 +23,7 @@ export const FIRST_PIPEIN_ENDPOINT = 0x80;
 export const LAST_PIPEIN_ENDPOINT = 0x9f;
 export const FIRST_PIPEOUT_ENDPOINT = 0xa0;
 export const LAST_PIPEOUT_ENDPOINT = 0xbf;
-const PROTOCOL_VERSION = 18;
+const PROTOCOL_VERSION = 19;
 
 function makeError(e: any, msg: string) {
     const code = e instanceof FrontPanelError ? e.code : ErrorCode.Failed;
@@ -223,7 +223,8 @@ export class FrontPanel {
             fpgaVendor: info.data[22],
             interfaceCount: info.data[23],
             interfaceIndex: info.data[24],
-            configuresFromSystemFlash: info.data[25]
+            configuresFromSystemFlash: info.data[25],
+            hasQuadConfigFlash: info.data[26]
         };
         return result;
     }


### PR DESCRIPTION
Increment the protocol version to let the server know that we're aware
of this field existence.

---

The changes are trivial, but I took time to test them: I've temporarily modified FrontPanel server to return `true` for `hasQuadConfigFlash` and this made the "get device info" test fail, as expected. Without this change, the test passes.